### PR TITLE
explicitly ignore errors

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -74,9 +74,7 @@ module.exports = function (db, flumedb) {
   if (flumedb) {
     var prog = { current: 0, start: 0, target: 0 }
 
-    one({ reverse: true, limit: 1 }, function (err, last) {
-      if (err) throw err
-
+    one({ reverse: true, limit: 1 }, function (_, last) {
       if (!last) ready() // empty legacy database.
       else {
         flumedb.since.once(function (v) {
@@ -119,10 +117,12 @@ module.exports = function (db, flumedb) {
           )
         }
       }
-      function ready (err) {
-        if (err) throw err
+      function ready (_) {
         flumedb.ready.set(true)
       }
     })
   }
 }
+
+
+

--- a/minimal.js
+++ b/minimal.js
@@ -139,9 +139,7 @@ module.exports = function (dirname, keys, opts) {
     }
   }
 
-  db.last.get(function (err, last) {
-    if (err) throw err
-
+  db.last.get(function (_, last) {
     // copy to so we avoid weirdness, because this object
     // tracks the state coming in to the database.
     for (var k in last) {
@@ -237,3 +235,4 @@ module.exports = function (dirname, keys, opts) {
 
   return db
 }
+


### PR DESCRIPTION
`ssb-server` doesn't even start for me (with current master branch)

```
/home/dominic/c/ssb-db/legacy.js:78
      if (err) throw err
               ^
EncodingError: Unexpected token % in JSON at position 0
    at /home/dominic/c/ssb-db/node_modules/level-sublevel/node_modules/levelup/lib/read-stream.js:60:28
    at /home/dominic/c/ssb-db/node_modules/level/node_modules/abstract-leveldown/abstract-iterator.js:29:14
    at /home/dominic/c/ssb-db/node_modules/level/node_modules/encoding-down/index.js:126:5
    at /home/dominic/c/ssb-db/node_modules/level/node_modules/abstract-leveldown/abstract-iterator.js:29:14
    at /home/dominic/c/ssb-db/node_modules/level/node_modules/leveldown/iterator.js:45:7
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

but the problem was just these throws where added in https://github.com/ssbc/ssb-db/commit/e18528401f71b6d498625a2187a6f803b882c900 to support `standard`. let the record show that adopting standard _caused bugs_.