### PR TITLE
add osenv to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "monotonic-timestamp": "~0.0.8",
     "muxrpc-validation": "^3.0.0",
     "obv": "0.0.1",
+    "osenv": "^0.1.5",
     "pull-cont": "^0.1.1",
     "pull-stream": "^3.4.0",
     "ssb-keys": "^7.1.3",


### PR DESCRIPTION
`osenv` is required in index.js https://github.com/ssbc/ssb-db/blob/e97198694e61ea96150c948198f516f4f2223005/index.js#L5 but was missing from package.json