### PR TITLE
add mkdirp to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "flumeview-reduce": "^1.3.9",
     "ltgt": "^2.2.0",
     "mdmanifest": "^1.0.8",
+    "mkdirp": "~0.5.0",
     "monotonic-timestamp": "~0.0.8",
     "muxrpc-validation": "^3.0.0",
     "obv": "0.0.1",


### PR DESCRIPTION
`mkdirp` is required in index.js https://github.com/ssbc/ssb-db/blob/e97198694e61ea96150c948198f516f4f2223005/index.js#L6 but was missing from package.json.