### PR TITLE
add rimraf to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "obv": "0.0.1",
     "pull-cont": "^0.1.1",
     "pull-stream": "^3.4.0",
+    "rimraf": "^2.4.2",
     "ssb-keys": "^7.1.3",
     "ssb-msgs": "^5.0.0",
     "ssb-ref": "^2.12.0",


### PR DESCRIPTION
`rimraf` is required in index.js https://github.com/ssbc/ssb-db/blob/e97198694e61ea96150c948198f516f4f2223005/index.js#L7 but was missing from package.json.