### PR TITLE
add zerr to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ssb-msgs": "^5.0.0",
     "ssb-ref": "^2.12.0",
     "ssb-validate": "^4.0.0",
-    "typewiselite": "^1.0.0"
+    "typewiselite": "^1.0.0",
+    "zerr": "^1.0.0"
   },
   "devDependencies": {
     "hexpp": "^2.0.0",


### PR DESCRIPTION
`zerr` is required in lib/validators.js https://github.com/ssbc/ssb-db/blob/e97198694e61ea96150c948198f516f4f2223005/lib/validators.js#L2 but was missing from package.json.