### PR TITLE
get ({id: id, meta: true}) to get {key,value,timestamp} format message

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ ssb-db works.
 
 The following methods all apply to a `ssb-db` instance
 
+### SSBdb#get (id | seq | opts, cb)
+
+Get an ssb message. If `id` is a message id, the message is returned.
+If seq is provided, the message at that offset in the underlying flumelog
+is returned. If opts is passed, the message id is taken from either
+`opts.id` or `opts.key`. If `opts.private = true` the message will be decrypted
+if possible. If `opts.meta = true` is set, or `seq` is used, the message will
+be in `{key, value: msg, timestamp}` format. Otherwise the raw message (without key and timestamp)
+are returned. This is for backwards compatibility reasons. Given that most other apis
+(such as createLogStream) by default return `{key, value, timestamp}` it's recommended
+to use `get({id: key, meta: true}, cb)`
+
 ### SSBdb#createFeed (keys?)
 
 Create a Feed object. A feed is a chain of messages signed
@@ -327,4 +339,6 @@ Stable: Expect patches, possible features additions.
 ## License
 
 MIT
+
+
 

--- a/create.js
+++ b/create.js
@@ -36,9 +36,11 @@ module.exports = function (path, opts, keys) {
   db.get = function (key, cb) {
     let isPrivate = false
     let unbox
+    let meta = false
     if (typeof key === 'object') {
       isPrivate = key.private === true
       unbox = key.unbox
+      meta = key.meta
       key = key.id
     }
 
@@ -58,14 +60,15 @@ module.exports = function (path, opts, keys) {
           result = u.originalValue(data.value)
         }
 
-        cb(null, result)
+        cb(null, !meta ? result : {key: data.key, value: result, timestamp: data.timestamp})
       })
     } else if (ref.isMsgLink(key)) {
       var link = ref.parseLink(key)
       return db.get({
         id: link.link,
         private: true,
-        unbox: link.query.unbox.replace(/\s/g, '+')
+        unbox: link.query.unbox.replace(/\s/g, '+'),
+        meta: link.query.meta
       }, cb)
     } else if (Number.isInteger(key)) {
       _get(key, cb) // seq
@@ -148,5 +151,7 @@ module.exports = function (path, opts, keys) {
 
   return db
 }
+
+
 
 

--- a/test/add.js
+++ b/test/add.js
@@ -32,13 +32,17 @@ module.exports = function (opts) {
         if (err) throw err
 
         t.deepEqual(_msg, msg.value)
-        f.add({ type: 'wtf' }, function (err, msg) {
-          if (err) throw err
-          console.log(msg)
-          ssb.get(msg.key, function (err, _msg) {
+        ssb.get({id:msg.key, meta: true}, function (err, _msg2) {
+          t.deepEqual(_msg2, msg)
+
+          f.add({ type: 'wtf' }, function (err, msg) {
             if (err) throw err
-            t.deepEqual(_msg, msg.value)
-            t.end()
+            console.log(msg)
+            ssb.get(msg.key, function (err, _msg) {
+              if (err) throw err
+              t.deepEqual(_msg, msg.value)
+              t.end()
+            })
           })
         })
       })
@@ -78,3 +82,4 @@ module.exports = function (opts) {
 }
 
 if (!module.parent) { module.exports({}) }
+


### PR DESCRIPTION
it is kinda annoying that lots of things use a `{key,value,timestamp}` pattern but `sbot.get` doesn't do that.
this tends to mean that sometimes messages don't have received times... this adds a option to keep that.

`meta` is short for metadata. using this name is consistent with other uses for example `links` which uses takes a `meta` option (although that one defaults to true)

Making meta default to true here is probably a breaking change.