### PR TITLE
documentation drive: document most important methods, list still undocumented methods, shift deprecated methods to deprecated section

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,13 +119,11 @@ module.exports = {
 
       since                    : since,
 
-      getPublicKey             : ssb.getPublicKey,
       latest                   : ssb.latest,
       getLatest                : valid.async(ssb.getLatest, 'feedId'),
       latestSequence           : valid.async(ssb.latestSequence, 'feedId'),
       createFeed               : ssb.createFeed,
       whoami                   : function () { return { id: feed.id } },
-      query                    : ssb.query,
       createFeedStream         : valid.source(ssb.createFeedStream, 'readStreamOpts?'),
       createHistoryStream      : valid.source(ssb.createHistoryStream, ['createHistoryStreamOpts'], ['feedId', 'number?', 'boolean?']),
       createLogStream          : valid.source(ssb.createLogStream, 'readStreamOpts?'),
@@ -141,4 +139,6 @@ module.exports = {
     }
   }
 }
+
+
 


### PR DESCRIPTION
The documentation was previously _very bad_ this improves it significantly.

rate the current state of the documentation out of 10 - 2 (now much improved)
is it clear what this is used for? - needs more guidance around how to create ssb plugins, and setting up minimal ssb set ups.
is there api documentation? - Yes
read code, do you see any undocumented methods? - quite a few, but these are explicitly listed.
for a method is there any undocumented options? - probably, yes

