### PR TITLE
Add option not to delete tmp based .ssb directory if a directory of the configured name already exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,12 @@ module.exports = {
     if(opts.temp) {
       var name = isString(opts.temp) ? opts.temp : ''+Date.now()
       opts.path = path.join(osenv.tmpdir(), name)
-      rimraf.sync(opts.path)
+
+      if (!opts.startUclean) {
+        // The 'startUnclean' option allows the caller to not remove the old temp directory with the given name
+        // if it exists. 
+        rimraf.sync(opts.path)
+      }
     }
 
     // load/create secure scuttlebutt data directory


### PR DESCRIPTION
I'm currently using https://github.com/ssbc/scuttle-testbot to test something. It would be useful for a test case I'm working on to be able to retain the old `tmp` directory.