### PR TITLE
Add support for deleting entire feed at once

### DIFF
--- a/api.md
+++ b/api.md
@@ -322,9 +322,10 @@ Outputs information in the following form:
 
 ⚠ This could break your feed. Please don't run this unless you understand it.
 
-Delete a message by its message or feed key. This only deletes the message from
-your local database, not the network, and could have unintended consequences if
-you try to delete a single message in the middle of a feed.
+Delete a message by its message key or a whole feed by its key. This only
+deletes the message from your local database, not the network, and could have
+unintended consequences if you try to delete a single message in the middle of
+a feed.
 
 The intended use-case is to delete all messages from a given feed *or* deleting
 a single message from the tip of your feed if you're completely confident that

--- a/api.md
+++ b/api.md
@@ -322,9 +322,9 @@ Outputs information in the following form:
 
 ⚠ This could break your feed. Please don't run this unless you understand it.
 
-Delete a message by its message key. This only deletes the message from your
-local database, not the network, and could have unintended consequences if you
-try to delete a single message in the middle of a feed.
+Delete a message by its message or feed key. This only deletes the message from
+your local database, not the network, and could have unintended consequences if
+you try to delete a single message in the middle of a feed.
 
 The intended use-case is to delete all messages from a given feed *or* deleting
 a single message from the tip of your feed if you're completely confident that
@@ -332,6 +332,12 @@ the message hasn't left your device.
 
 ```javascript
 del(msg.key, (err) => {
+  if (err) throw err
+})
+```
+
+```javascript
+del(msg.value.author, (err) => {
   if (err) throw err
 })
 ```

--- a/create.js
+++ b/create.js
@@ -44,7 +44,6 @@ module.exports = function (path, opts, keys) {
           cb(err, key)
         })
       }),
-      pull.filter(),
       pull.collect(cb)
     )
   }

--- a/create.js
+++ b/create.js
@@ -51,7 +51,7 @@ module.exports = function (path, opts, keys) {
   const deleteMessage = (key, cb) => {
     db.keys.get(key, (err, val, seq) => {
       if (err) return cb(err)
-      if (seq == null) cb(new Error('seq is null!'))
+      if (seq == null) return cb(new Error('seq is null!'))
 
       _del(seq, cb)
     })

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = {
 
   //    usage                    : valid.sync(usage, 'string?|boolean?'),
       close                    : close,
-      del: valid.async(ssb.del, 'msgLink'),
+      del: valid.async(ssb.del, 'msgLink|feedId'),
       publish                  : valid.async(feed.add, 'string|msgContent'),
       add                      : valid.async(ssb.add, 'msg'),
       queue                      : valid.async(ssb.queue, 'msg'),

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   },
   "dependencies": {
     "async-write": "^2.1.0",
-    "cont": "~1.0.0",
-    "explain-error": "~1.0.1",
     "flumedb": "^1.1.0",
     "flumelog-offset": "^3.4.2",
     "flumeview-level": "^3.0.13",
@@ -29,15 +27,16 @@
     "ssb-msgs": "^5.0.0",
     "ssb-ref": "^2.12.0",
     "ssb-validate": "^4.0.0",
-    "typewiselite": "^1.0.0",
     "zerr": "^1.0.0"
   },
   "devDependencies": {
+    "cont": "~1.0.0",
+    "explain-error": "~1.0.1",
     "hexpp": "^2.0.0",
     "pull-abortable": "~4.1.0",
     "ssb-feed": "^2.2.1",
     "tape": "^4.8.0",
-    "typewiselite": "~1.0.0"
+    "typewiselite": "^1.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm ls && npm test",

--- a/test/log.js
+++ b/test/log.js
@@ -137,7 +137,7 @@ module.exports = function (opts) {
     })
   })
 
-  tape('delete', (t) => {
+  tape('delete message', (t) => {
     var ssb = createSSB('test-ssb-log8')
 
     var feed = createFeed(ssb, generate(), opts)
@@ -165,6 +165,35 @@ module.exports = function (opts) {
           )
         })
       )
+    })
+  })
+
+  tape('delete feed', (t) => {
+    var ssb = createSSB('test-ssb-log9')
+    var feed = createFeed(ssb, generate(), opts)
+
+    t.plan(5)
+
+    feed.add('msg', 'hello there!', function (err) {
+      t.error(err)
+      feed.add('msg', 'hello again!', function (err, msg) {
+        t.error(err)
+        ssb.del(msg.value.author, err => {
+          t.error(err)
+          pull(
+            ssb.createFeedStream(),
+            pull.drain(() => {
+              t.fail('no messages should be available')
+            }, () => {
+              ssb.get(msg.key, (err) => {
+                t.ok(err)
+                t.equal(err.code, 'flumelog:deleted')
+                t.end()
+              })
+            })
+          )
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
This is what we're doing manually in Patchwork, except for in Patchwork we're also keeping track of messages that are currently in the process of being deleted because it's common to call `del()` on the same message multiple times. I'm unsure whether we should:

- Add some code to support race conditions so `del()` can be called lots without errors.
- Leave as-is and probably have scenarios where `del()` called repeatedly throws errors.

Relevant Patchwork code: https://github.com/ssbc/patchwork/blob/a7dd2056bf17f0986cf3f8e4445fac3e024fb4ef/lib/main-window.js#L81-L121