### PR TITLE
remove mdmanifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,21 +4,39 @@ var path       = require('path')
 var osenv      = require('osenv')
 var mkdirp     = require('mkdirp')
 var rimraf     = require('rimraf')
-var mdm        = require('mdmanifest')
 var valid      = require('./lib/validators')
 var pkg        = require('./package.json')
 
 function isString(s) { return 'string' === typeof s }
 function isObject(o) { return 'object' === typeof o }
 function isFunction (f) { return 'function' === typeof f }
-// create SecretStack definition
-var fs = require('fs')
-var manifest = mdm.manifest(fs.readFileSync(path.join(__dirname, 'api.md'), 'utf-8'))
 
-manifest.seq = 'async'
-manifest.usage = 'sync'
-manifest.clock = 'async'
-manifest.version = 'sync'
+var manifest = {
+  get: 'async',
+  createFeedStream: 'source',
+  createLogStream: 'source',
+  messagesByType: 'source',
+  createHistoryStream: 'source',
+  createUserStream: 'source',
+  createWriteStream: 'sink',
+  links: 'source',
+  add: 'async',
+  publish: 'async',
+  getAddress: 'sync',
+  getLatest: 'async',
+  latest: 'source',
+  latestSequence: 'async',
+  whoami: 'sync',
+  del: 'async',
+  progress: 'sync',
+  status: 'sync',
+  getVectorClock: 'async',
+  version: 'sync',
+  help: 'sync',
+  seq: 'async',
+  usage: 'sync',
+  clock: 'async'
+}
 
 module.exports = {
   manifest: manifest,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "flumeview-level": "^3.0.13",
     "flumeview-reduce": "^1.3.9",
     "ltgt": "^2.2.0",
-    "mdmanifest": "^1.0.8",
     "mkdirp": "^0.5.1",
     "monotonic-timestamp": "~0.0.8",
     "muxrpc-validation": "^3.0.0",


### PR DESCRIPTION
mdmanifest used to be widely used in ssb libraries, but not so much nowadays. ssb-db is the only one still using, as far as I know.

In codebases like Manyverse, we have to [patch the source code](https://github.com/staltz/manyverse/blob/3e6f756d8e67e19aefd7eb158718c4168bd893d5/tools/patch-backend-ssb-server#L29) of ssb-db to replace mdmanifest usage, because it does a `fs.readFileSync` on non-JavaScript files expected to be in node_modules, but those files are deleted because we run `noderify` and delete all other files, in order to drastically decrease the amount of bytes shipped to the user's app download or update.

Another justification for this is that mdmanifest doesn't help that much, but creates "two sources of truth" which need to be synchronized. JavaScript is not the single authority concerning the definition of a muxrpc API, but also Markdown is. So if you (say) rename `createHistoryStream` to `createHistory`, you have to change that in both JS and api.md. Ideally, we should have one source of truth: either (1) JS is fully generated from markdown, or (2) markdown docs are generated from JS. (2) is actually quite common, it's doable through JSDocs for instance. There are several tools out there to generate markdown from JS, see for instance [markdox](https://github.com/cbou/markdox).

So this PR just removes mdmanifest as a dependency, and hardcodes the manifest in index.js.