### PR TITLE
Add secret-stack name for simpler debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ var manifest = {
 }
 
 module.exports = {
+  name: 'db',
   manifest: manifest,
   permissions: {
     master: {allow: null, deny: null},


### PR DESCRIPTION
Right now we aren't exporting a name, so it's hard to introspect which plugin this is without looking at the manifest.