### PR TITLE
Revert "Add secret-stack name for simpler debugging"

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ var manifest = {
 }
 
 module.exports = {
-  name: 'db',
   manifest: manifest,
   permissions: {
     master: {allow: null, deny: null},


### PR DESCRIPTION
Reverts #268 because it breaks ssb-db via muxrpc. I'm planning to add a backward-compat plugin as a sibling that exports everything with deprecation stack traces (except `createHistoryStream()`, of course).