### PR TITLE
Change Travis tests to replace Node 6 with Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
   - 8
   - 10
+  - 12
 env:
   - CXX=g++-4.8
 


### PR DESCRIPTION
Node 8 is almost at EOL, so I think it's probably fine to finally drop Node 6 support in favor of the active LTS.