### PR TITLE
Add boxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,10 +450,25 @@ an [observable](https://github.com/dominictarr/obv) of the current log sequence.
 is always a positive integer that usually increases, except in the exceptional circumstance
 that the log is deleted or corrupted.
 
-### db.addUnboxer({key:unboxKey, value: unboxValue})
+### db.addBoxer(box)
+
+add a box, which will be added to the list of boxers which will try to
+automatically box (encrypt) the message `content` if the appropriate
+`content.recps` is provided.
+
+`box` is a function of signature `box(content, recps) => (String|null)`
+which is expected to either box the the message content and return a ciphertext String, or return null if it unable to.
+
+### db.addUnboxer({key: unboxKey, value: unboxValue})
 
 add an unboxer object, any encrypted message is passed to the unboxer object to
 test if it can be unboxed (decrypted)
+
+where
+- `unboxKey(ciphertext) => msgKey` is a function which tries to extract the message key from the encrypted content (`ciphertext`)
+- `unboxValue(ciphertext, msgKey) => plaintext` is a function which takes a message key and uses it to try to extract the message content from the `ciphertext`
+
+NOTE: There's an alternative way to use `addUnboxer` but read the source to understand that.
 
 ### db.unbox(data, key)
 

--- a/create.js
+++ b/create.js
@@ -2,11 +2,12 @@
 
 var join = require('path').join
 var EventEmitter = require('events')
-
 var pull = require('pull-stream')
 var ref = require('ssb-ref')
 var ssbKeys = require('ssb-keys')
 
+var createDB = require('./db')
+var extras = require('./extras')
 var u = require('./util')
 
 function isString (s) {
@@ -17,13 +18,13 @@ function errorCB (err) {
   if (err) throw err
 }
 
-module.exports = function (path, opts, keys) {
+module.exports = function create (path, opts, keys) {
   //_ was legacy db. removed that, but for backwards compatibilty reasons do not change interface
   if(!path) throw new Error('path must be provided')
 
   keys = keys || ssbKeys.generate()
 
-  var db = require('./db')(join(opts.path || path, 'flume'), keys, opts)
+  var db = createDB(join(opts.path || path, 'flume'), keys, opts)
 
   // UGLY HACK, but...
   // fairly sure that something up the stack expects ssb to be an event emitter.
@@ -140,7 +141,7 @@ module.exports = function (path, opts, keys) {
 
   // pull in the features that are needed to pass the tests
   // and that sbot, etc uses but are slow.
-  require('./extras')(db, opts, keys)
+  extras(db, opts, keys)
 
   // writeStream - used in (legacy) replication.
   db.createWriteStream = function (cb) {
@@ -185,7 +186,3 @@ module.exports = function (path, opts, keys) {
 
   return db
 }
-
-
-
-

--- a/db.js
+++ b/db.js
@@ -1,6 +1,6 @@
 var FlumeviewLevel = require('flumeview-level')
 
-module.exports = function (dir, keys, opts) {
+module.exports = function db (dir, keys, opts) {
   const db = require('./minimal')(dir, keys, opts)
     .use('keys', FlumeviewLevel(3, (msg) => [ msg.key ]))
     .use('clock', require('./indexes/clock')())

--- a/index.js
+++ b/index.js
@@ -106,7 +106,11 @@ module.exports = {
       },
 
       status                   : function () {
-        return {progress: self.progress(), db: ssb.status, sync: since() }
+        return {
+          progress: self.progress(),
+          db: ssb.status,
+          sync: since()
+        }
       },
 
       version                  : function () {
@@ -114,17 +118,16 @@ module.exports = {
       },
 
       //temporary!
-      _flumeUse                :
-        function (name, flumeview) {
-          ssb.use(name, flumeview)
-          return ssb[name]
-        },
+      _flumeUse                : function (name, flumeview) {
+        ssb.use(name, flumeview)
+        return ssb[name]
+      },
 
       close                    : close,
-      del: valid.async(ssb.del, 'msgLink|feedId'),
+      del                      : valid.async(ssb.del, 'msgLink|feedId'),
       publish                  : valid.async(feed.add, 'string|msgContent'),
       add                      : valid.async(ssb.add, 'msg'),
-      queue                      : valid.async(ssb.queue, 'msg'),
+      queue                    : valid.async(ssb.queue, 'msg'),
       get                      : valid.async(ssb.get, 'msgLink|number|object'),
 
       post                     : ssb.post,
@@ -147,12 +150,10 @@ module.exports = {
       createWriteStream        : ssb.createWriteStream,
       getVectorClock           : ssb.getVectorClock,
       getAtSequence            : ssb.getAtSequence,
+      addBoxer                 : ssb.addBoxer,
       addUnboxer               : ssb.addUnboxer,
       box                      : ssb.box,
       help                     : function () { return require('./help') }
     }
   }
 }
-
-
-

--- a/minimal.js
+++ b/minimal.js
@@ -28,7 +28,7 @@ function box (content, recps, boxers) {
     'private message requested, but no boxers could encrypt these recps: ' +
     JSON.stringify(recps)
   )
-  
+
   return ciphertext
 }
 
@@ -250,7 +250,7 @@ module.exports = function (dirname, keys, opts) {
     var recps = value.content.recps
     if (!recps) return value.content
 
-    if (typeof recps === 'string') recps = [recps]
+    if (typeof recps === 'string') recps = value.content.recps = [recps]
     if (!Array.isArray(recps)) throw new Error('private message field "recps" expects an Array of recipients')
     if (recps.length === 0) throw new Error('private message field "recps" requires at least one recipient')
 

--- a/minimal.js
+++ b/minimal.js
@@ -237,8 +237,8 @@ module.exports = function (dirname, keys, opts) {
       return ssbKeys.box(content, recps)
     },
     unbox: {
-      key: function (content) { return ssbKeys.unboxKey(content, keys) },
-      value: function (content, key) { return ssbKeys.unboxBody(content, key) }
+      key: function (ciphertext) { return ssbKeys.unboxKey(ciphertext, keys) },
+      value: function (ciphertext, key) { return ssbKeys.unboxBody(ciphertext, key) }
     }
   }
   db.addBoxer(box1.box)

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -76,17 +76,13 @@ module.exports = function (opts) {
     })
   })
 
-  tape('add encrypted message', function (t) {
+  tape('add encrypted message (using recps: String)', function (t) {
     ssb.post(function (msg) {
       t.equal('string', typeof msg.value.content, 'messages should not be decrypted')
     })
 
     // secret message sent to self
-    feed.add({
-      recps: feed.id,
-      type: 'secret2',
-      secret: "it's a secret!"
-    }, function (err, msg) {
+    feed.add({ type: 'secret2', secret: "it's a secret!", recps: feed.id }, function (err, msg) {
       if (err) throw err
       t.notOk(err)
 
@@ -99,11 +95,11 @@ module.exports = function (opts) {
 
           // bob can also decrypt
           var content = ssbKeys.unbox(ctxt, alice.private)
-          t.deepEqual(content, {
-            type: 'secret2',
-            secret: "it's a secret!",
-            recps: [alice.id]
-          }, 'alice can decrypt')
+          t.deepEqual(
+            content,
+            { type: 'secret2', secret: "it's a secret!", recps: [alice.id] },
+            'alice can decrypt'
+          )
 
           t.end()
         })


### PR DESCRIPTION
In working on private groups I'm keen to register new boxers (as well as unboxers).

This PR adds:
- adds `db.addBoxer` which follows a similar pattern to `addUnboxer`
- moves private-box (box1) code to use the new API (in preparation to extract it!)