### PR TITLE
async boxers / unboxers

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,8 +467,13 @@ add an unboxer object, any encrypted message is passed to the unboxer object to
 test if it can be unboxed (decrypted)
 
 where
-- `unboxKey(ciphertext) => msgKey` is a function which tries to extract the message key from the encrypted content (`ciphertext`)
-- `unboxValue(ciphertext, msgKey) => plaintext` is a function which takes a message key and uses it to try to extract the message content from the `ciphertext`
+- `unboxKey(msg.value.content, msg.value, cb)`
+  - is a function which tries to extract the message key from the encrypted content (`ciphertext`).
+  - is expected to callback `cb(err, msgKey)` which `msgKey` is the key for the message
+- `unboxValue(msg.value.content, msgKey, msg.value, cb)`
+  - is a function which takes a `msgKey` and uses it to try to extract the plaintext from the `ciphertext`
+  - is expected to callback `cb(err, plaintext)`
+
 
 NOTE: There's an alternative way to use `addUnboxer` but read the source to understand that.
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ add a `boxer`, which will be added to the list of boxers which will try to
 automatically box (encrypt) the message `content` if the appropriate
 `content.recps` is provided.
 
-`boxer` is a function of signature `boxer(content, recps) => ciphertext` which is expected either:
+`boxer` is a function of signature `boxer(msg.value.content, msg.value.content.recps) => ciphertext` which is expected either:
 - successfully box, returning a `ciphertext` String
 - communicate that it can't box this by returning undefined (or null)
 - communicate it hit a problem by throwing an error
@@ -467,11 +467,11 @@ add an unboxer object, any encrypted message is passed to the unboxer object to
 test if it can be unboxed (decrypted)
 
 where
-- `unboxKey(msg.value.content, msg.value) => msgKey`
+- `unboxKey(msg.value.content, msg.value) => readKey`
     - is a function which tries to extract the message key from the encrypted content (`ciphertext`).
-    - is expected to return `msgKey` which is the key for the message
-- `unboxValue(msg.value.content, msgKey) => plainContent`
-    - is a function which takes a `msgKey` and uses it to try to extract the `plainContent` from the `ciphertext- `initBoxer(done)`
+    - is expected to return `readKey` which is the read capability for the message
+- `unboxValue(msg.value.content, msg.value, readKey) => plainContent`
+    - is a function which takes a `readKey` and uses it to try to extract the `plainContent` from the `ciphertext- `initBoxer(done)`
     - is an optional initialisation function (useful for asynchronously setting up state for unboxer)
     - it's pased a `done` callback which you need to call once everything is ready to go
 

--- a/README.md
+++ b/README.md
@@ -450,14 +450,16 @@ an [observable](https://github.com/dominictarr/obv) of the current log sequence.
 is always a positive integer that usually increases, except in the exceptional circumstance
 that the log is deleted or corrupted.
 
-### db.addBoxer(box)
+### db.addBoxer(boxer)
 
-add a box, which will be added to the list of boxers which will try to
+add a `boxer`, which will be added to the list of boxers which will try to
 automatically box (encrypt) the message `content` if the appropriate
 `content.recps` is provided.
 
-`box` is a function of signature `box(content, recps) => (String|null)`
-which is expected to either box the the message content and return a ciphertext String, or return null if it unable to.
+`box` is a function of signature `box(content, recps, cb)` which is expected either:
+- successfully box, calling back with a `ciphertext` String - `cb(null, ciphertext)`
+- communicate that it can't box this - `cb(null, null)`
+- communicate that it thought it could box this but hit an error - `cb(err)`
 
 ### db.addUnboxer({key: unboxKey, value: unboxValue})
 
@@ -469,6 +471,11 @@ where
 - `unboxValue(ciphertext, msgKey) => plaintext` is a function which takes a message key and uses it to try to extract the message content from the `ciphertext`
 
 NOTE: There's an alternative way to use `addUnboxer` but read the source to understand that.
+
+### db.box(content, recps, cb)
+
+attempt to encrypt some `content` to `recps` (an Array of keys/ identifiers).
+callback has signature `cb(err, ciphertext)`
 
 ### db.unbox(data, key)
 

--- a/README.md
+++ b/README.md
@@ -456,10 +456,10 @@ add a `boxer`, which will be added to the list of boxers which will try to
 automatically box (encrypt) the message `content` if the appropriate
 `content.recps` is provided.
 
-`boxer` is a function of signature `boxer(msg.value.content, msg.value.content.recps) => ciphertext` which is expected either:
-- successfully box, returning a `ciphertext` String
-- communicate that it can't box this by returning undefined (or null)
-- communicate it hit a problem by throwing an error
+`boxer` is a function of signature `boxer(msg.value.content) => ciphertext` which is expected to:
+- successfully box the content (based on `content.recps`), returning a `ciphertext` String
+- not know how to box this content (because recps are outside it's understanding), and `undefined` (or `null`)
+- break (because it should know how to handle `recps`, but can't), and so throw an `Error`
 
 ### db.addUnboxer({ key: unboxKey, value: unboxValue, init: initBoxer })
 

--- a/README.md
+++ b/README.md
@@ -456,24 +456,24 @@ add a `boxer`, which will be added to the list of boxers which will try to
 automatically box (encrypt) the message `content` if the appropriate
 `content.recps` is provided.
 
-`box` is a function of signature `box(content, recps, cb)` which is expected either:
-- successfully box, calling back with a `ciphertext` String - `cb(null, ciphertext)`
-- communicate that it can't box this - `cb(null, null)`
-- communicate that it thought it could box this but hit an error - `cb(err)`
+`box` is a function of signature `box(content, recps) => ciphertext` which is expected either:
+- successfully box, returning a `ciphertext` String
+- communicate that it can't box this by returning undefined (or null)
+- communicate it hit a problem by throwing an error
 
-### db.addUnboxer({key: unboxKey, value: unboxValue})
+### db.addUnboxer({ key: unboxKey, value: unboxValue, init: initBoxer })
 
 add an unboxer object, any encrypted message is passed to the unboxer object to
 test if it can be unboxed (decrypted)
 
 where
-- `unboxKey(msg.value.content, msg.value, cb)`
+- `unboxKey(msg.value.content, msg.value) => msgKey`
   - is a function which tries to extract the message key from the encrypted content (`ciphertext`).
-  - is expected to callback `cb(err, msgKey)` which `msgKey` is the key for the message
-- `unboxValue(msg.value.content, msgKey, msg.value, cb)`
-  - is a function which takes a `msgKey` and uses it to try to extract the plaintext from the `ciphertext`
-  - is expected to callback `cb(err, plaintext)`
-
+  - is expected to return `msgKey` which is the key for the message
+- `unboxValue(msg.value.content, msgKey) => plainContent`
+  - is a function which takes a `msgKey` and uses it to try to extract the `plainContent` from the `ciphertext- `initBoxer(done)`
+  - is an optional initialisation function (useful for asynchronously setting up state for unboxer)
+  - it's pased a `done` callback which you need to call once everything is ready to go
 
 NOTE: There's an alternative way to use `addUnboxer` but read the source to understand that.
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ add a `boxer`, which will be added to the list of boxers which will try to
 automatically box (encrypt) the message `content` if the appropriate
 `content.recps` is provided.
 
-`box` is a function of signature `box(content, recps) => ciphertext` which is expected either:
+`boxer` is a function of signature `boxer(content, recps) => ciphertext` which is expected either:
 - successfully box, returning a `ciphertext` String
 - communicate that it can't box this by returning undefined (or null)
 - communicate it hit a problem by throwing an error
@@ -468,12 +468,12 @@ test if it can be unboxed (decrypted)
 
 where
 - `unboxKey(msg.value.content, msg.value) => msgKey`
-  - is a function which tries to extract the message key from the encrypted content (`ciphertext`).
-  - is expected to return `msgKey` which is the key for the message
+    - is a function which tries to extract the message key from the encrypted content (`ciphertext`).
+    - is expected to return `msgKey` which is the key for the message
 - `unboxValue(msg.value.content, msgKey) => plainContent`
-  - is a function which takes a `msgKey` and uses it to try to extract the `plainContent` from the `ciphertext- `initBoxer(done)`
-  - is an optional initialisation function (useful for asynchronously setting up state for unboxer)
-  - it's pased a `done` callback which you need to call once everything is ready to go
+    - is a function which takes a `msgKey` and uses it to try to extract the `plainContent` from the `ciphertext- `initBoxer(done)`
+    - is an optional initialisation function (useful for asynchronously setting up state for unboxer)
+    - it's pased a `done` callback which you need to call once everything is ready to go
 
 NOTE: There's an alternative way to use `addUnboxer` but read the source to understand that.
 

--- a/autobox.js
+++ b/autobox.js
@@ -4,21 +4,20 @@ function isFunction (f) { return typeof f === 'function' }
 function isString (s) { return typeof s === 'string' }
 
 function box (content, boxers) {
-  var recps = content.recps
-  if (!recps) return content
+  if (!content.recps) return content
 
-  if (typeof recps === 'string') recps = content.recps = [recps]
-  if (!Array.isArray(recps)) throw new Error('private message field "recps" expects an Array of recipients')
-  if (recps.length === 0) throw new Error('private message field "recps" requires at least one recipient')
+  if (typeof content.recps === 'string') content.recps = [content.recps]
+  if (!Array.isArray(content.recps)) throw new Error('private message field "recps" expects an Array of recipients')
+  if (content.recps.length === 0) throw new Error('private message field "recps" requires at least one recipient')
 
   var ciphertext
   for (var i = 0; i < boxers.length; i++) {
     const boxer = boxers[i]
-    ciphertext = boxer(content, recps)
+    ciphertext = boxer(content)
 
     if (ciphertext) break
   }
-  if (!ciphertext) throw RecpsError(recps)
+  if (!ciphertext) throw RecpsError(content.recps)
 
   return ciphertext
 }

--- a/autobox.js
+++ b/autobox.js
@@ -30,7 +30,7 @@ function RecpsError (recps) {
   )
 }
 
-function unbox (msg, msgKey, unboxers) {
+function unbox (msg, readKey, unboxers) {
   if (!msg || !isString(msg.value.content)) return msg
 
   var plain
@@ -41,8 +41,8 @@ function unbox (msg, msgKey, unboxers) {
       plain = unboxer(msg.value.content, msg.value)
     }
     else {
-      if (!msgKey) msgKey = unboxer.key(msg.value.content, msg.value)
-      if (msgKey) plain = unboxer.value(msg.value.content, msgKey)
+      if (!readKey) readKey = unboxer.key(msg.value.content, msg.value)
+      if (readKey) plain = unboxer.value(msg.value.content, msg.value, readKey)
     }
     if (plain) break
   }
@@ -62,13 +62,13 @@ function unbox (msg, msgKey, unboxers) {
 
     // set meta properties for private messages
     value.meta.private = true
-    if (msgKey) { value.meta.unbox = msgKey.toString('base64') }
+    if (readKey) { value.meta.unbox = readKey.toString('base64') }
 
     // backward-compatibility with previous property location
     // this property location may be deprecated in favor of `value.meta`
     value.cyphertext = value.meta.original.content
     value.private = value.meta.private
-    if (msgKey) { value.unbox = value.meta.unbox }
+    if (readKey) { value.unbox = value.meta.unbox }
 
     return {
       key: msg.key,

--- a/autobox.js
+++ b/autobox.js
@@ -1,0 +1,84 @@
+const { metaBackup } = require('./util')
+
+function isFunction (f) { return typeof f === 'function' }
+function isString (s) { return typeof s === 'string' }
+
+function box (content, boxers) {
+  var recps = content.recps
+  if (!recps) return content
+
+  if (typeof recps === 'string') recps = content.recps = [recps]
+  if (!Array.isArray(recps)) throw new Error('private message field "recps" expects an Array of recipients')
+  if (recps.length === 0) throw new Error('private message field "recps" requires at least one recipient')
+
+  var ciphertext
+  for (var i = 0; i < boxers.length; i++) {
+    const boxer = boxers[i]
+    ciphertext = boxer(content, recps)
+
+    if (ciphertext) break
+  }
+  if (!ciphertext) throw RecpsError(recps)
+
+  return ciphertext
+}
+
+function RecpsError (recps) {
+  return new Error(
+    'private message requested, but no boxers could encrypt these recps: ' +
+    JSON.stringify(recps)
+  )
+}
+
+function unbox (msg, msgKey, unboxers) {
+  if (!msg || !isString(msg.value.content)) return msg
+
+  var plain
+  for (var i = 0; i < unboxers.length; i++) {
+    const unboxer = unboxers[i]
+
+    if (isFunction(unboxer)) {
+      plain = unboxer(msg.value.content, msg.value)
+    }
+    else {
+      if (!msgKey) msgKey = unboxer.key(msg.value.content, msg.value)
+      if (msgKey) plain = unboxer.value(msg.value.content, msgKey)
+    }
+    if (plain) break
+  }
+
+  if (!plain) return msg
+  return decorate(msg, plain)
+
+  function decorate (msg, plain) {
+    var value = {}
+    for (var k in msg.value) { value[k] = msg.value[k] }
+
+    // set `meta.original.content`
+    value.meta = metaBackup(value, 'content')
+
+    // modify content now that it's saved at `meta.original.content`
+    value.content = plain
+
+    // set meta properties for private messages
+    value.meta.private = true
+    if (msgKey) { value.meta.unbox = msgKey.toString('base64') }
+
+    // backward-compatibility with previous property location
+    // this property location may be deprecated in favor of `value.meta`
+    value.cyphertext = value.meta.original.content
+    value.private = value.meta.private
+    if (msgKey) { value.unbox = value.meta.unbox }
+
+    return {
+      key: msg.key,
+      value,
+      timestamp: msg.timestamp
+    }
+  }
+}
+
+module.exports = {
+  box,
+  unbox
+}

--- a/create.js
+++ b/create.js
@@ -83,19 +83,18 @@ module.exports = function create (path, opts, keys) {
       return db.keys.get(key, function (err, data) {
         if (err) return cb(err)
 
-        if (isPrivate && unbox) {
-          data = db.unbox(data, unbox)
+        if (!isPrivate) {
+          if (meta) cb(null, { key, value: data.value, timestamp: data.timestamp })
+          else cb(null, data.value)
         }
+        else {
+          db.unbox(data, unbox, function (err, result) {
+            if (err) return cb(err)
 
-        let result
-
-        if (isPrivate) {
-          result = data.value
-        } else {
-          result = u.originalValue(data.value)
+            if (meta) cb(null, { key, value: result.value, timestamp: result.timestamp })
+            else cb(null, result.value)
+          })
         }
-
-        cb(null, !meta ? result : {key: data.key, value: result, timestamp: data.timestamp})
       })
     } else if (ref.isMsgLink(key)) {
       var link = ref.parseLink(key)

--- a/create.js
+++ b/create.js
@@ -88,12 +88,10 @@ module.exports = function create (path, opts, keys) {
           else cb(null, data.value)
         }
         else {
-          db.unbox(data, unbox, function (err, result) {
-            if (err) return cb(err)
+          const result = db._unbox(data, unbox)
 
-            if (meta) cb(null, { key, value: result.value, timestamp: result.timestamp })
-            else cb(null, result.value)
-          })
+          if (meta) cb(null, { key, value: result.value, timestamp: result.timestamp })
+          else cb(null, result.value)
         }
       })
     } else if (ref.isMsgLink(key)) {

--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ module.exports = {
       getAtSequence            : ssb.getAtSequence,
       addBoxer                 : ssb.addBoxer,
       addUnboxer               : ssb.addUnboxer,
-      box                      : ssb.box,
       help                     : function () { return require('./help') }
     }
   }

--- a/minimal.js
+++ b/minimal.js
@@ -6,8 +6,6 @@ var AsyncWrite = require('async-write')
 var V = require('ssb-validate')
 var timestamp = require('monotonic-timestamp')
 var Obv = require('obv')
-var ssbKeys = require('ssb-keys')
-var isFeed = require('ssb-ref').isFeed
 var u = require('./util')
 var codec = require('./codec')
 var { box, unbox } = require('./autobox')
@@ -185,33 +183,6 @@ module.exports = function (dirname, keys, opts) {
     })
   })
   setup.runAll()
-
-  // TODO extract to ssb-private //////
-  var box1 = {
-    boxer: (content, recps) => {
-      if (!recps.every(isFeed)) return
-
-      return ssbKeys.box(content, recps)
-    },
-    unboxer: {
-      // init: (done) => {
-      //   // loads trial keys into box1State (memory)
-      //   done()
-      // },
-      key: (ciphertext, msg) => {
-        if (!ciphertext.endsWith('.box')) return
-        // todo move this inside of ssb-keys
-
-        return ssbKeys.unboxKey(ciphertext, keys)
-      },
-      value: (ciphertext, msg, readKey) => {
-        return ssbKeys.unboxBody(ciphertext, readKey)
-      }
-    }
-  }
-  db.addBoxer(box1.boxer)
-  db.addUnboxer(box1.unboxer)
-  // /TODO /////////////////////////////
 
   return db
 }

--- a/minimal.js
+++ b/minimal.js
@@ -204,8 +204,8 @@ module.exports = function (dirname, keys, opts) {
 
         return ssbKeys.unboxKey(ciphertext, keys)
       },
-      value: (ciphertext, msgKey) => {
-        return ssbKeys.unboxBody(ciphertext, msgKey)
+      value: (ciphertext, msg, readKey) => {
+        return ssbKeys.unboxBody(ciphertext, readKey)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "hexpp": "^2.0.0",
     "pull-abortable": "^4.1.1",
     "ssb-feed": "^2.2.1",
+    "ssb-private1": "^1.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.8.0",
+    "tape": "^4.13.2",
     "typewiselite": "^1.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm ls && npm test",
-    "test": "set -e; for t in test/*.js; do node $t | tap-spec; done"
+    "test": "set -e; for t in test/*.js; do node $t; done",
+    "test:pretty": "npm test | tap-spec"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "hexpp": "^2.0.0",
     "pull-abortable": "^4.1.1",
     "ssb-feed": "^2.2.1",
+    "tap-spec": "^5.0.0",
     "tape": "^4.8.0",
     "typewiselite": "^1.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm ls && npm test",
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "set -e; for t in test/*.js; do node $t | tap-spec; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT",

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -221,8 +221,8 @@ module.exports = function (opts) {
   })
 
   tape('addBoxer', function (t) {
-    const boxer = (content, recps) => {
-      if (!recps.every(r => r === '!test')) return
+    const boxer = (content) => {
+      if (!content.recps.every(r => r === '!test')) return
 
       return Buffer.from(JSON.stringify(content)).toString('base64') + '.box.hah'
     }

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -184,10 +184,10 @@ module.exports = function (opts) {
   })
 
   tape('addBoxer', function (t) {
-    const boxer = (content, recps) => {
-      if (!recps.every(r => r === '!test')) return null
+    const boxer = (content, recps, cb) => {
+      if (!recps.every(r => r === '!test')) return cb(null, null)
 
-      return Buffer.from(JSON.stringify(content)).toString('base64') + '.box.hah'
+      cb(null, Buffer.from(JSON.stringify(content)).toString('base64') + '.box.hah')
     }
     ssb.addBoxer(boxer)
 

--- a/test/close.js
+++ b/test/close.js
@@ -3,29 +3,33 @@ var tape = require('tape')
 var pull = require('pull-stream')
 
 var createSSB = require('./create-ssb')
+var keys = require('ssb-keys').generate()
+var content = { type: 'whatever' }
 
 tape('load', function (t) {
-  var ssb = createSSB('test-ssb-feed')
+  t.plan(1)
+  var ssb = createSSB('test-ssb-feed', { keys })
 
-  ssb.createFeed().add({ type: 'whatever' }, function (err, msg) {
+  ssb.createFeed().add(content, function (err, msg) {
     if (err) throw err
-    //  t.end()
-    console.log(msg)
+    // console.log(msg)
+
     ssb.close(function () {
-      t.end()
+      t.ok(true, 'closes + runs callback')
     })
   })
 })
 
 tape('reopen', function (t) {
-  var ssb = createSSB('test-ssb-feed', { temp: false })
+  t.plan(1)
+  var ssb = createSSB('test-ssb-feed', { keys, temp: false })
 
   pull(
     ssb.createLogStream(),
     pull.collect(function (err, ary) {
       if (err) throw err
-      console.log(ary, ssb.since.value)
-      t.end()
+
+      t.deepEqual(ary[0].value.content, content, 'reopen works fine')
     })
   )
 })

--- a/test/create-ssb.js
+++ b/test/create-ssb.js
@@ -1,12 +1,12 @@
 var ssbKeys = require('ssb-keys')
 
-module.exports = function createSSB (name, opts, keys) {
+module.exports = function createSSB (name, opts) {
   opts = opts || {}
   var dir = require('path').join(require('osenv').tmpdir(), name)
   if (opts.temp !== false) {
     require('rimraf').sync(dir)
     require('mkdirp').sync(dir)
   }
-  opts.keys = opts.keys || ssbKeys.generate()
-  return require('../create')(dir, opts, opts.keys)
+  var keys = opts.keys = opts.keys || ssbKeys.generate()
+  return require('../create')(dir, opts, keys)
 }


### PR DESCRIPTION
WIP:

:fire: This is a breaking change

## Motivation
I need to be able to do async lookups to look for appropriate keys for private-groups. 
This requires changing how boxers / unboxers work from sync > async.



---

## Questions

what in the ecosystem is currently using these APIs `box` / `unbox`, `addBoxer` / `addUnboxer`?

## TODO

if we're cutting a major release I intend to extract the box1 boxers/ unboxers so that they are optionally added as opposed to always on.