### PR TITLE
Upgrade FlumeDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "async-write": "^2.1.0",
-    "flumedb": "^1.1.0",
+    "flumedb": "^2.1.1",
     "flumelog-offset": "^3.4.2",
     "flumeview-level": "^3.0.13",
     "flumeview-reduce": "^1.3.9",


### PR DESCRIPTION
Problem: The old version of FlumeDB can't auto-heal broken indexes.

Solution: Upgrade FlumeDB to ^2.1.1.