### PR TITLE
Fix `test/close.js` on async-box with `{ temp }`

### DIFF
--- a/test/close.js
+++ b/test/close.js
@@ -26,7 +26,7 @@ tape('reopen', function (t) {
   t.plan(1)
 
   // HACK: See readme section on 'known bugs'.
-  setImmediate(() => {
+  setTimeout(() => {
     var ssb = createSSB(name, { keys, temp: false })
 
     pull(
@@ -37,5 +37,5 @@ tape('reopen', function (t) {
         t.deepEqual(ary[0].value.content, content, 'reopen works fine')
       })
     )
-  })
+  }, 100)
 })

--- a/test/close.js
+++ b/test/close.js
@@ -24,14 +24,18 @@ tape('load', function (t) {
 
 tape('reopen', function (t) {
   t.plan(1)
-  var ssb = createSSB(name, { keys, temp: false })
 
-  pull(
-    ssb.createLogStream(),
-    pull.collect(function (err, ary) {
-      if (err) throw err
+  // HACK: See readme section on 'known bugs'.
+  setImmediate(() => {
+    var ssb = createSSB(name, { keys, temp: false })
 
-      t.deepEqual(ary[0].value.content, content, 'reopen works fine')
-    })
-  )
+    pull(
+      ssb.createLogStream(),
+      pull.collect(function (err, ary) {
+        if (err) throw err
+
+        t.deepEqual(ary[0].value.content, content, 'reopen works fine')
+      })
+    )
+  })
 })

--- a/test/close.js
+++ b/test/close.js
@@ -8,7 +8,7 @@ var content = { type: 'whatever' }
 
 tape('load', function (t) {
   t.plan(1)
-  var ssb = createSSB('test-ssb-feed', { keys })
+  var ssb = createSSB('test-ssb-feed', { keys, temp: false })
 
   ssb.createFeed().add(content, function (err, msg) {
     if (err) throw err

--- a/test/close.js
+++ b/test/close.js
@@ -6,9 +6,11 @@ var createSSB = require('./create-ssb')
 var keys = require('ssb-keys').generate()
 var content = { type: 'whatever' }
 
+const name = `test-ssb-close-${Date.now()}`
+
 tape('load', function (t) {
   t.plan(1)
-  var ssb = createSSB('test-ssb-feed', { keys, temp: false })
+  var ssb = createSSB(name, { keys, temp: false })
 
   ssb.createFeed().add(content, function (err, msg) {
     if (err) throw err
@@ -22,7 +24,7 @@ tape('load', function (t) {
 
 tape('reopen', function (t) {
   t.plan(1)
-  var ssb = createSSB('test-ssb-feed', { keys, temp: false })
+  var ssb = createSSB(name, { keys, temp: false })
 
   pull(
     ssb.createLogStream(),


### PR DESCRIPTION
Problem: The `test/close.js` test was failing because the database
seems to have been empty, and since `createLogStream()` doesn't emit
items on an empty database then `pull.collect()` is never called. The
database is empty because the first test creates a database where `temp`
is implicitly true, which uses a directory like `/tmp/1590008707854`.
When the second test sets `temp` to false, it uses a named directory
like `/tmp/test-ssb-feed`, which is **empty**.

Solution: Pass `{ temp: false }` consistently to both tests.