### PR TITLE
WIP upgrade to tape@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ssb-feed": "^2.2.1",
     "ssb-private1": "^1.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.13.2",
+    "tape": "^5.0.0",
     "typewiselite": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
was doing some work the other day and upgraded the dependency for one reason or another.
It generated new failing tests ... specifically I _think_ it might be catching tests which are run _after `t.end()` has been called_ . 

This seems like a useful thing to look into more at some point