### PR TITLE
Add test for unbox failing without unboxer

### DIFF
--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -31,6 +31,20 @@ module.exports = function (opts) {
 
   var feed = ssb.createFeed(alice)
 
+  tape('error when trying to encrypt without boxer', (t) => {
+    t.plan(2);
+    const darlene = ssbKeys.generate()
+    const darleneSSB = createSSB('test-ssb-darlene', { keys: darlene })
+    const darleneFeed = ssb.createFeed(darlene)
+    darleneFeed.add(
+      { type: "error", recps: [alice, darlene] },
+      (err, msg) => {
+	t.ok(err);
+	t.notOk(msg);
+        t.end()
+      })
+  })
+
   tape('add pre-encrypted message', function (t) {
     var original = { type: 'secret', okay: true }
     var boxed = ssbKeys.box(original, [alice.public, bob.public])


### PR DESCRIPTION
Problem: Now that boxers are optional, I'm worried that a future
programming mistake might see a message with `recps` properties that
doesn't get boxed because no boxer is available.

Solution: Add a test to ensure that this does not currently happen and
cannot happen in the future.

---

Test fails because of #290 