### PR TITLE
put an LRU cache over unbox

### DIFF
--- a/minimal.js
+++ b/minimal.js
@@ -6,20 +6,23 @@ var AsyncWrite = require('async-write')
 var V = require('ssb-validate')
 var timestamp = require('monotonic-timestamp')
 var Obv = require('obv')
+var mkdirp = require('mkdirp')
 var u = require('./util')
 var codec = require('./codec')
-var { box, unbox } = require('./autobox')
-const mkdirp = require('mkdirp')
+var { box, unbox: _unbox } = require('./autobox')
 
 module.exports = function (dirname, keys, opts) {
-  var caps = opts && opts.caps || {}
+  var caps = (opts && opts.caps) || {}
   var hmacKey = caps.sign
-
-  var boxers = []
-  var unboxers = []
 
   mkdirp.sync(dirname)
   var log = OffsetLog(path.join(dirname, 'log.offset'), { blockSize: 1024 * 16, codec })
+
+  var boxers = []
+  var unboxers = []
+  var unbox = _unbox.withCache()
+  // NOTE unbox.withCache needs to be instantiated *inside* this scope
+  // otherwise the cache is shared across instances!
 
   const unboxerMap = wait((msg, cb) => {
     try {
@@ -166,6 +169,12 @@ module.exports = function (dirname, keys, opts) {
 
   db._unbox = function dbUnbox (msg, msgKey) {
     return unbox(msg, msgKey, unboxers)
+  }
+
+  const _rebuild = db.rebuild
+  db.rebuild = function (cb) {
+    unbox.resetCache()
+    _rebuild(cb)
   }
 
   /* initialise some state */

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "flumelog-offset": "^3.4.2",
     "flumeview-level": "^4.0.3",
     "flumeview-reduce": "^1.3.17",
+    "hashlru": "^2.3.0",
     "ltgt": "^2.2.0",
     "mkdirp": "^0.5.1",
     "monotonic-timestamp": "~0.0.8",

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -75,6 +75,7 @@ module.exports = function () {
           t.deepEqual(pmsg.value.content, original, 'did not mutate original message')
 
           const rawMsg = originalValue(pmsg.value) // puts all the ciphertext back in place, strips meta
+
           ssb2.add(rawMsg, function (err) {
             if (err) throw err
 


### PR DESCRIPTION
```
/* NOTE
 * currently when flumedb passes messages to each view (index) it runs
 * an unbox on encrypted messaged FOR EVERY VIEW
 *
 * This is a temporary easy solution to reduce some wasted CPU cycles
 * without having to change deep things about flumedb
 */
```

This PR uses an LRU style cache to _bound_ the amount of the memory this unbox cache will use.

This needs to take into account index rebuilds in the context where you've just been given a private group key. This is why there's (untested) code which closes over the `flume.rebuild` function 
