### PR TITLE
upgrade mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,16 @@
         "obv": "^0.0.1",
         "rwlock": "^5.0.0",
         "uint48be": "^2.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "ansi-regex": {
@@ -758,12 +768,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "monotonic-timestamp": {
       "version": "0.0.9",
@@ -1219,6 +1226,16 @@
         "chloride": "^2.2.8",
         "mkdirp": "~0.5.0",
         "private-box": "^0.3.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "ssb-msgs": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "flumeview-level": "^4.0.3",
     "flumeview-reduce": "^1.3.17",
     "ltgt": "^2.2.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "monotonic-timestamp": "~0.0.8",
     "muxrpc-validation": "^3.0.0",
     "obv": "0.0.1",


### PR DESCRIPTION
there was some security warning about minimist which mkdirp depends on.
noticed there was a major version with a simialr API (for our purposes, so bumped)