### PR TITLE
travis: add mac+win

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
+# Use Node.js configuration.
 language: node_js
-sudo: false
+
 node_js:
-  - 8
   - 10
   - 12
-env:
-  - CXX=g++-4.8
+  - node # latest
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-
-before_install:
-  - export JOBS=max
-  - export prebuild_compile=true
-
-
+os:
+  - linux
+  - osx
+  - windows
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "type": "git",
     "url": "git://github.com/ssbc/ssb-db.git"
   },
+  "scripts": {
+    "prepublishOnly": "npm ls && npm test",
+    "test": "tape test/*.js",
+    "test:classic": "set -e; for t in test/*.js; do node $t; done",
+    "test:pretty": "npm test | tap-spec"
+  },
   "dependencies": {
     "async-write": "^2.1.0",
     "flumedb": "^2.1.4",
@@ -39,11 +45,6 @@
     "tap-spec": "^5.0.0",
     "tape": "^4.13.2",
     "typewiselite": "^1.0.0"
-  },
-  "scripts": {
-    "prepublishOnly": "npm ls && npm test",
-    "test": "set -e; for t in test/*.js; do node $t; done",
-    "test:pretty": "npm test | tap-spec"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT",

--- a/test/add.js
+++ b/test/add.js
@@ -3,11 +3,11 @@ var tape = require('tape')
 var pull = require('pull-stream')
 var crypto = require('crypto')
 
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
-module.exports = function (opts) {
-  var ssb = createSSB('test-ssb-feed', {})
-  var ssb2 = createSSB('test-ssb-feed2', {})
+function run (opts) {
+  var ssb = createSSB('test-ssb-add', {})
+  var ssb2 = createSSB('test-ssb-add2', {})
 
   tape('add invalid message', function (t) {
     ssb.add({}, function (err) {
@@ -81,5 +81,4 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
-
+run()

--- a/test/append.js
+++ b/test/append.js
@@ -1,20 +1,20 @@
 var V = require('ssb-validate')
 var tape = require('tape')
 var ssbKeys = require('ssb-keys')
-var keys = ssbKeys.generate()
-
 var pull = require('pull-stream')
 var explain = require('explain-error')
 var timestamp = require('monotonic-timestamp')
 
+var minimal = require('../minimal')
+
+var keys = ssbKeys.generate()
 var dirname = '/tmp/test_ssb_append' + Date.now()
 
 var K = [keys]
-
 for (var i = 0; i < 100; i++) K.push(ssbKeys.generate())
 
 var a
-var db = a = require('../minimal')(dirname)
+var db = a = minimal(dirname)
 db.ready.set(true)
 var MSG
 tape('setup', function (t) {

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -5,10 +5,10 @@ var ssbKeys = require('ssb-keys')
 var box1 = require('ssb-private1/box1')
 const { promisify } = require('util')
 
-var createSSB = require('./create-ssb')
 var { originalValue } = require('../util')
+var createSSB = require('./util/create-ssb')
 
-module.exports = function () {
+function run () {
   var alice = ssbKeys.generate()
   var bob = ssbKeys.generate()
   var charles = ssbKeys.generate()
@@ -399,10 +399,9 @@ module.exports = function () {
         // createRawLogStream currently not exported as a method
 
         t.end()
-
       })
     })
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()

--- a/test/close.js
+++ b/test/close.js
@@ -1,9 +1,10 @@
 'use strict'
 var tape = require('tape')
 var pull = require('pull-stream')
-
-var createSSB = require('./create-ssb')
 var keys = require('ssb-keys').generate()
+
+var createSSB = require('./util/create-ssb')
+
 var content = { type: 'whatever' }
 
 const name = `test-ssb-close-${Date.now()}`

--- a/test/feed.js
+++ b/test/feed.js
@@ -3,9 +3,9 @@ var tape = require('tape')
 var pull = require('pull-stream')
 var ssbKeys = require('ssb-keys')
 var createFeed = require('ssb-feed')
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
-module.exports = function (opts) {
+function run (opts) {
   tape('simple', function (t) {
     var ssb = createSSB('test-ssb-feed')
     var feed = ssb.createFeed(ssbKeys.generate())
@@ -159,4 +159,5 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()
+

--- a/test/history.js
+++ b/test/history.js
@@ -1,14 +1,12 @@
 'use strict'
 
-var pull = require('pull-stream')
 var tape = require('tape')
-
+var pull = require('pull-stream')
 var Abortable = require('pull-abortable')
-
-var createSSB = require('./create-ssb')
-
 var compare = require('ltgt').compare
 var generate = require('ssb-keys').generate
+
+var createSSB = require('./util/create-ssb')
 
 // create a instance with a feed
 // then have another instance follow it.
@@ -25,7 +23,7 @@ function sort (ary) {
   })
 }
 
-module.exports = function (opts) {
+function run (opts) {
   var create = require('ssb-feed/util').create
 
   function init (ssb, n, cb) {
@@ -193,4 +191,5 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()
+

--- a/test/latest.js
+++ b/test/latest.js
@@ -3,7 +3,7 @@
 var tape = require('tape')
 var pull = require('pull-stream')
 var cont = require('cont')
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
 var db = createSSB('test-ssb-latest')
 

--- a/test/links.js
+++ b/test/links.js
@@ -3,7 +3,7 @@
 var tape = require('tape')
 var pull = require('pull-stream')
 var cont = require('cont')
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
 function cmpstr (a, b) {
   return a < b ? -1 : a === b ? 0 : 1
@@ -14,8 +14,8 @@ function compare (a, b) {
 //  return a.key < b.key ? -1 : a.key === b.key ? 0 : -1
 }
 
-module.exports = function (opts) {
-  var db = createSSB('test-ssb-feed')
+function run (opts) {
+  var db = createSSB('test-ssb-links')
 
   var alice = db.createFeed()
   var bob = db.createFeed()
@@ -132,4 +132,4 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()

--- a/test/linktypes.js
+++ b/test/linktypes.js
@@ -4,9 +4,9 @@ var pull = require('pull-stream')
 var cont = require('cont')
 var typewise = require('typewiselite')
 var ssbKeys = require('ssb-keys')
-
-var createSSB = require('./create-ssb')
 var createFeed = require('ssb-feed')
+
+var createSSB = require('./util/create-ssb')
 
 function sort (a) {
   return a.sort(function (a, b) {
@@ -19,8 +19,8 @@ function sort (a) {
   })
 }
 
-module.exports = function (opts) {
-  var ssb = createSSB('test-ssb-links')
+function run (opts = {}) {
+  var ssb = createSSB('test-ssb-linktypes')
 
   var all = function (stream) {
     return function (cb) {
@@ -251,4 +251,5 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()
+

--- a/test/log.js
+++ b/test/log.js
@@ -4,11 +4,12 @@ var pull = require('pull-stream')
 var timestamp = require('monotonic-timestamp')
 var ssbKeys = require('ssb-keys')
 var createFeed = require('ssb-feed')
-var createSSB = require('./create-ssb')
+
+var createSSB = require('./util/create-ssb')
 
 var generate = ssbKeys.generate
 
-module.exports = function (opts) {
+function run (opts = {}) {
   tape('simple', function (t) {
     var ssb = createSSB('test-ssb-log1')
 
@@ -198,4 +199,5 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()
+

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -2,7 +2,7 @@
 var tape = require('tape')
 var { manifest, init } = require('../')
 
-module.exports = function () {
+function run () {
   tape('manifest', t => {
     const _api = {}
     const opts = {
@@ -20,4 +20,4 @@ module.exports = function () {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()

--- a/test/mesages-by-type.js
+++ b/test/mesages-by-type.js
@@ -3,13 +3,13 @@ var cont = require('cont')
 var pull = require('pull-stream')
 var ssbKeys = require('ssb-keys')
 var createFeed = require('ssb-feed')
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
 function all (stream, cb) {
   pull(stream, pull.collect(cb))
 }
 
-module.exports = function (opts) {
+function run (opts = {}) {
   tape('retrive messages by type', function (t) {
     var dbA = createSSB('msg-by-type1')
     var alice = createFeed(dbA, ssbKeys.generate(), opts)
@@ -77,4 +77,4 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()

--- a/test/msg-encoding.js
+++ b/test/msg-encoding.js
@@ -5,12 +5,12 @@ var ssbKeys = require('ssb-keys')
 var createFeed = require('ssb-feed')
 var hexpp = require('hexpp')
 var codec = require('../codec')
-var createSSB = require('./create-ssb')
+var createSSB = require('./util/create-ssb')
 
 var generate = ssbKeys.generate
 var hash = ssbKeys.hash
 
-module.exports = function (opts) {
+function run (opts = {}) {
   var content = {
     'type': 'post',
     'is': 'text',
@@ -81,4 +81,4 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()

--- a/test/rebuild.js
+++ b/test/rebuild.js
@@ -1,9 +1,8 @@
 const tape = require("tape");
-const createSsb = require("./create-ssb");
 const FlumeviewLevel = require('flumeview-level')
-
-
 const { promisify } = require("util");
+
+const createSsb = require("./util/create-ssb");
 
 tape("basic rebuild", async (t) => {
   const db = createSsb();

--- a/test/util/create-ssb.js
+++ b/test/util/create-ssb.js
@@ -4,11 +4,12 @@ const mkdirp = require("mkdirp");
 const path = require("path");
 const os = require("os");
 const crypto = require("crypto");
-const create = require('../create');
+
+const create = require('../../create');
 
 const randomName = () => crypto.randomBytes(16).toString("hex");
 
-module.exports = function createSSB(name = randomName(), opts = {}) {
+module.exports = function createSSB (name = randomName(), opts = {}) {
   const dir = path.join(os.tmpdir(), name);
 
   if (opts.temp !== false) {

--- a/test/validation.js
+++ b/test/validation.js
@@ -5,9 +5,10 @@ var explain = require('explain-error')
 var generate = require('ssb-keys').generate
 var hash = require('ssb-keys').hash
 var v = require('ssb-validate')
-var createSSB = require('./create-ssb')
 
-module.exports = function (opts) {
+var createSSB = require('./util/create-ssb')
+
+function run (opts = {}) {
   var create = require('ssb-feed/util').create
   var ssb = createSSB('test-ssb-validate')
 
@@ -169,4 +170,5 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports(require('../')) }
+run()
+

--- a/test/write-stream.js
+++ b/test/write-stream.js
@@ -2,10 +2,11 @@
 var tape = require('tape')
 var pull = require('pull-stream')
 var ssbKeys = require('ssb-keys')
-var createSSB = require('./create-ssb')
 
-module.exports = function (opts) {
-  var ssb = createSSB('test-ssb-feed')
+var createSSB = require('./util/create-ssb')
+
+function run (opts = {}) {
+  var ssb = createSSB('test-ssb-write-stream')
   var create = require('ssb-feed/util').create
 
   tape('write-stream', function (t) {
@@ -68,4 +69,4 @@ module.exports = function (opts) {
   })
 }
 
-if (!module.parent) { module.exports({}) }
+run()


### PR DESCRIPTION
This PR changes:
1. the travis config:
    - adds Mac + Windows
    - the general config (:warning: I've just changed it, don't know what the implications are)
2. hows the tests are run
    - moved to using tape as a runner so windows can run
    - this has necessitated a refactor of the tests files

I've checked the number of tests before / after and ensured that 265 tests are still being run