### PR TITLE
Fix pass-by-reference from cache

### DIFF
--- a/autobox.js
+++ b/autobox.js
@@ -1,5 +1,6 @@
 const HLRU = require('hashlru')
 const { metaBackup } = require('./util')
+const cloneDeep = require('lodash.clonedeep')
 
 function isFunction (f) { return typeof f === 'function' }
 function isString (s) { return typeof s === 'string' }
@@ -100,7 +101,7 @@ function unboxWithCache (id) {
     const cached = cache.get(msg.key)
 
     if (cached === false && !readKey) return msg
-    else if (cached) return cached
+    else if (cached) return cloneDeep(cached)
 
     const result = unbox(msg, readKey, unboxers)
     if (isString(result.value.content)) cache.set(msg.key, false)

--- a/create.js
+++ b/create.js
@@ -40,7 +40,6 @@ module.exports = function create (path, opts, keys) {
   // - adds methods:
   //   - db.createLogStream
   //   - db.createFeedStream
-  //   - db.creareUserStream
   //   - db.latest
   //   - db.latestSequence
   //   - db.getLatest

--- a/test/unbox-with-cache.js
+++ b/test/unbox-with-cache.js
@@ -87,21 +87,24 @@ tape('unbox.withCache - source', (t) => {
 // This test ensures that one query doesn't mutate the results of another
 // query. This was written to illustrate a problem where `unboxValue()` would
 // **mutate the results of other queries** and re-box messages that were meant
-// to be private.
-tape('shared mutable state (passive)', (t) => {
+// to be private (in the cache)
+tape('unboxWithCache - no shared mutable state (passive)', (t) => {
   const ssb = createSsb(`shared-mutable-state-${Date.now}`, {}, [require('ssb-private1')])
 
-  ssb.publish({ type: 'test', recps: [ssb.id]}, (err) => {
+  ssb.publish({ type: 'boop', recps: [ssb.id] }, (err) => {
     t.error(err)
 
+    const query = { id: ssb.id, reverse: true, limit: 1, private: true }
     pull(
-      ssb.createUserStream({ id: ssb.id, reverse: true, limit: 1, private: true }),
+      ssb.createUserStream(query),
       pull.collect((err, privateMessages) => {
         t.error(err)
         const copy = cloneDeep(privateMessages)
         pull(
-          ssb.createUserStream({ id: ssb.id, reverse: true, limit: 1 }),
+          ssb.createUserStream(Object.assign(query, { private: false })),
           pull.collect((err) => {
+            // we don't care about the results of this query, we want to see that the last results
+            // were not mutated by performing it
             t.error(err)
             t.deepEqual(privateMessages, copy, 'unrelated query should not mutate original results')
             ssb.close(t.end)
@@ -112,10 +115,10 @@ tape('shared mutable state (passive)', (t) => {
   })
 })
 
-tape('shared mutable state (active)', (t) => {
+tape('unbox.withCache - no shared mutable state (active)', (t) => {
   const ssb = createSsb(`shared-mutable-state-${Date.now}`, {}, [require('ssb-private1')])
 
-  ssb.publish({ type: 'test', recps: [ssb.id]}, (err) => {
+  ssb.publish({ type: 'boop', recps: [ssb.id] }, (err) => {
     t.error(err)
 
     pull(
@@ -125,7 +128,7 @@ tape('shared mutable state (active)', (t) => {
         const copy = cloneDeep(privateMessageA)
         pull(
           ssb.createUserStream({ id: ssb.id, reverse: true, limit: 1, private: true }),
-          pull.collect((err, [privateMessageB]) => {
+          pull.collect((_, [privateMessageB]) => {
             privateMessageA.value = 'this should not effect privateMessageB'
             t.deepEqual(copy, privateMessageB, 'active tampering should not mutate variables')
             ssb.close(t.end)


### PR DESCRIPTION
Problem: HashLRU passes references, not values, so when we use the cache
we're accidentally creating a scenario where one variable being mutated
can change the contents of the results of another query.

Solution: Use `lodash.cloneDeep()` on the results from the HashLRU cache
to ensure that we're always passing by value rather than by reference.

---

I was going to make an issue for this, but I figured I should just fix it instead. I think this is better than `Object.freeze()` because that makes you *think* that you can change an object (no errors) but quietly drops any changes that you try to make.