### PR TITLE
Fix intermittent Windows test failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ module.exports = {
           _close((err) => {
             setImmediate(() => {
               if (typeof cb === 'function') {
+                if (typeof err === 'object' && err !== null && err.code === 'ERR_SERVER_NOT_RUNNING') {
+                  // https://github.com/ssbc/ssb-db/issues/300
+                  err = null
+                }
                 cb(err)
               }
             })


### PR DESCRIPTION
Problem: For some reason the Travis CI Windows builds fail
intermittently with a specific error that doesn't make any sense to me.
We've been just restarting the build, since the erorr (can't close the
server because the server is already closed) doesn't matter, but it's
still very obnoxious.

Solution: Ignore the error entirely and don't worry about it. I don't
think that we care if the server is already closed, the important thing
is that it's closed. I'm okay with `close()` being idempotent.

Resolves: #300 