### PR TITLE
expose "previous" message id

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,11 +579,24 @@ Callback when all queued writes are actually definitely written to the disk.
 
 ## db.post: Observable
 ```js
-db.post(fn({key, value: msg, timestamp})) => Ovb
+db.post(fn({key, value: msg, timestamp})) => Obv
 ```
 
-[Observable](https://github.com/dominictarr/obv) that calls `fn` whenever a message is appended (with that 
-message). __This method is not exposed over RPC.__
+[Observable](https://github.com/dominictarr/obv) that calls `fn` whenever a message is appended
+(with that message).
+
+__This method is not exposed over RPC.__
+
+## db.previous: Observable
+```js
+db.previous(fn(MsgId)) => Obv
+```
+
+[Observable](https://github.com/dominictarr/obv) that calls `fn` whenever **a message is validated and queued for append**
+NOTE this happens earlier than `db.post`, as that observeable updates on successful append, whereas this updates.
+This is needed for the case where we are boxing messages based on the message before it in the queue.
+
+__This method is not exposed over RPC.__
 
 ## db.since: Observable
 ```js

--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ module.exports = {
       get                      : valid.async(ssb.get, 'msgLink|number|object'),
 
       post                     : ssb.post,
+      previous                 : ssb.previous,
       addMap                   : ssb.addMap,
 
       since                    : since,

--- a/minimal.js
+++ b/minimal.js
@@ -82,6 +82,7 @@ module.exports = function (dirname, keys, opts) {
 
   var append = db.rawAppend = db.append
   db.post = Obv()
+  db.previous = Obv()
 
   let writing = false
 
@@ -116,6 +117,8 @@ module.exports = function (dirname, keys, opts) {
   const queue = (message, cb) => {
     try {
       V.append(state, hmacKey, message)
+      const previous = state.feeds[keys.id] ? state.feeds[keys.id].id : null
+      db.previous.set(previous)
       cb(null, state.queue[state.queue.length - 1])
       if (writing === false) {
         write()


### PR DESCRIPTION
This needs some closer attention .... like what's the initial state of `previous` and when does that get loaded?
I've plugged this into `ssb-tribes` and it indeed fixes the previous bug where things are boxed wrong because we are pointing at the wrong previous