### PR TITLE
Pass feed state to boxer

### DIFF
--- a/autobox.js
+++ b/autobox.js
@@ -5,7 +5,7 @@ const cloneDeep = require('lodash.clonedeep')
 function isFunction (f) { return typeof f === 'function' }
 function isString (s) { return typeof s === 'string' }
 
-function box (content, boxers) {
+function box (content, boxers, feedState) {
   if (!content.recps) return content
 
   if (typeof content.recps === 'string') content.recps = [content.recps]
@@ -15,7 +15,7 @@ function box (content, boxers) {
   var ciphertext
   for (var i = 0; i < boxers.length; i++) {
     const boxer = boxers[i]
-    ciphertext = boxer(content)
+    ciphertext = boxer(content, feedState)
 
     if (ciphertext) break
   }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var manifest = {
   getVectorClock: 'async',
   help: 'sync',
   latest: 'source',
+  getFeedState: 'async',
   latestSequence: 'async',
   links: 'source',
   messagesByType: 'source',
@@ -154,6 +155,7 @@ module.exports = {
       since                    : since,
 
       latest                   : ssb.latest,
+      getFeedState             : valid.async(ssb.getFeedState, 'feedId'),
       getLatest                : valid.async(ssb.getLatest, 'feedId'),
       latestSequence           : valid.async(ssb.latestSequence, 'feedId'),
       createFeed               : ssb.createFeed,

--- a/test/append.js
+++ b/test/append.js
@@ -16,7 +16,7 @@ var K = [keys]
 for (var i = 0; i < 100; i++) K.push(ssbKeys.generate())
 
 var a
-var db = a = minimal(dirname)
+var db = a = minimal(dirname, keys)
 db.ready.set(true)
 var MSG
 tape('append (setup)', function (t) {
@@ -121,23 +121,36 @@ tape('append (read back)', function (t) {
 // usual `{ key, value }`. This test adds a bunch of messages very quickly and
 // ensures that the callback contains the correct data.
 tape('append (bulk)', (t) => {
-  const ssb = createSsb();
+  const ssb = createSsb()
 
   // We write 7919 messages, which should be bigger than any cache. It's also a
   // prime number and shouldn't line up perfectly with any batch sizes.
   const messages = 7919
 
-  const assertsPerMessage = 4;
-  t.plan(messages * assertsPerMessage);
+  const assertsPerMessage = 4
+  const plan = messages * assertsPerMessage
+  var pass = 0
+
+  function testEqual (a, b) {
+    if (a !== b) {
+      process.stdout.write('\n')
+      t.equal(a, b)
+      return
+    }
+    pass += 1
+  }
 
   Promise.all([...new Array(messages)].map(async (_, i) => {
-     const entry = await promisify(ssb.publish)({ type: 'test' })
-    t.equal(typeof entry, 'object')
-    t.equal(typeof entry.key, 'string')
-    t.equal(typeof entry.value, 'object')
-    t.equal(entry.value.sequence, i + 1)
+    const entry = await promisify(ssb.publish)({ type: 'test' })
+    process.stdout.write('.')
+
+    testEqual(typeof entry, 'object')
+    testEqual(typeof entry.key, 'string')
+    testEqual(typeof entry.value, 'object')
+    testEqual(entry.value.sequence, i + 1)
   })).then(() => {
+    process.stdout.write('\n')
+    t.equal(pass, plan, 'passed all tests')
     ssb.close(t.end)
   })
 })
-

--- a/test/get-feed-state.js
+++ b/test/get-feed-state.js
@@ -1,0 +1,33 @@
+const test = require('tape')
+const { promisify: p } = require('util')
+const { isMsg } = require('ssb-ref')
+const ssb = require('../').init({}, { temp: true })
+
+const getFeedState = p(ssb.getFeedState)
+const publish = p(ssb.publish)
+
+const myKey = ssb.keys.id
+const otherKey = '@zwRbK6ZFefbMDtPcM+q3Kdvwzr+RU9K0e/UFSFzlhuQ=.ed25519'
+
+test('getFeedState', async (t) => {
+  var initialState = await getFeedState(myKey)
+  t.deepEqual(initialState, { id: null, sequence: 0 }, 'empty feed')
+
+  await publish({ type: 'boop' })
+
+  var laterState = await getFeedState(ssb.keys.id)
+  t.equal(laterState.sequence, 1, 'sequence increases after publish')
+  t.true(isMsg(laterState.id), 'msgId present after publish')
+
+  var otherState = await getFeedState(otherKey)
+  t.deepEqual(otherState, { id: null, sequence: 0 }, 'returns null for remote feeds it does not know about')
+
+  try {
+    await getFeedState('cat')
+  } catch (e) {
+    t.match(e.message, /Param 0 must by of type feedId/)
+    // NOTE typo in auto-validation : by !== be
+  }
+
+  t.end()
+})


### PR DESCRIPTION
Alternative to #311 which automatically passes feed state to the boxer, exposing a method instead of an observable for further use.

---

Problem: Some boxers, like SSB-Tribe, depend on the feed state. We've
tried using hacks to query the database before publishing a message, but
we really just need to be passed the feed state (according to the
validator) each time the boxer is asked to box a message.

Solution: Pass the relevant feed state from the validator to the boxer.
There are also some circumstances where we want some specific feed
state, like when boxing a message to pass to `add()` rather than
`append()`, and so I've added a `getFeedState()` method that returns
those results.