### PR TITLE
update createHistoryStream opts.seq documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ safer for RPC between untrusted peers.
 supported. `createHistoryStream` does not decrypt private messages.
 
 - `id` *(FeedID)* The id of the feed to fetch.
-- `seq` *(number)* If `seq > 0`, then only stream messages with sequence numbers greater than `seq`. 
+- `seq` *(number)* If `seq > 0`, then only stream messages with sequence numbers greater than or equal to `seq`. 
 Defaults to `0`.
 - `live` *(boolean)*: Keep the stream open and emit new messages as they are received. Defaults to `false`
 - `keys` *(boolean)*: Whether the `data` event should contain keys. If set to `true` and `values` set to 


### PR DESCRIPTION
I discovered in testing `ssb-tribes` that `opts.seq` did not behave as the docs describe - there was an "out by one" error.

`createHistoryStream` is defined in `indexes/clock.js` : 

```js
    index.createHistoryStream = function (streamOpts) {
      const opts = u.options(streamOpts)
      var id = opts.id
      var seq = opts.sequence || opts.seq || 0
      var limit = opts.limit
      var keys = opts.keys
      var values = opts.values
      return pull(
        index.read({
          gte: [id, seq],                  // <<<<<<<<< greater than OR EQUAL TO
          lte: [id, MAX_INT],
          live: opts && opts.live,
          old: opts && opts.old,
          keys: false,
          sync: (opts && opts.sync) === false,
          limit: limit
        }),
        // NEVER allow private messages over history stream.
        // createHistoryStream is used for legacy replication.
        u.Format(keys, values, false)
      )
    }

```

this adjusts the README to help people avoid this (presumed) typo