### PR TITLE
db.get to return flumedb offset in the 3rd arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ Otherwise the raw message (without key and timestamp) are returned. This is for 
 Given that most other apis (such as createLogStream) by default return `{key, value, timestamp}` it's 
 recommended to use `db.get({id: key, meta: true}, cb)`
 
+Note that the `cb` callback is called with 3 arguments: `cb(err, msg, offset)`, where
+the 3rd argument is the `offset` position of that message in the log (flumelog-offset).
+
 ## db.add: async
 ```js
 db.add(msg, cb) // cb(error, data)

--- a/create.js
+++ b/create.js
@@ -66,7 +66,7 @@ module.exports = function create (path, opts, keys) {
     }
 
     if (ref.isMsg(key)) {
-      return db.keys.get(key, function (err, data) {
+      return db.keys.get(key, function (err, data, offset) {
         if (err) return cb(err)
 
         var value
@@ -81,8 +81,8 @@ module.exports = function create (path, opts, keys) {
 
         if (!value) value = data.value // if db._unbox fails value will be undefined
 
-        if (meta) cb(null, { key, value, timestamp: data.timestamp })
-        else cb(null, value)
+        if (meta) cb(null, { key, value, timestamp: data.timestamp }, offset)
+        else cb(null, value, offset)
       })
     }
     else if (Number.isInteger(key)) _get(key, cb) // seq


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/ssb-db2/pull/97

Problem: in ssb-db2 we need to efficiently perform migration from log.offset to log.bipf, and for that we need to retrieve the *offset on log.offset of the latest migrated record*, because our process works like this: (1) pick the last record in log.bipf, (2) pick its `msg.key`, (3) retrieve the record on log.offset that matches `msg.key`, (4) retrieve the offset of that record on log.offset, (5) continue scanning log.offset from that specific offset.

Solution: to perform steps (4) and (5), we need `get(msgkey, cb)` to give us also the offset. This PR returns the offset as the 3rd CB argument. Why the 3rd arg? Because it's backwards compatible with whatever ssb-db was doing and providing to other parts of the stack (i.e. we don't need to change the second arg, which would be a breaking change), **and** because flumedb already returns the offset as the 3rd arg, it would be natural to propagate that.